### PR TITLE
Fix wrong file refs and stale Bank Income link in READMEs

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -296,19 +296,19 @@ This attribute can be calculated for a single account or across all the users ac
 This attribute details the average of a user’s daily ending balances
 
 This attribute can be calculated for a single account or across all the users depository accounts.
-* Account level attribute: account/negative_record.py
-* Report level attribute: report/negative_record.py
+* Account level attribute: account/historical_balances.py
+* Report level attribute: report/historical_balances.py
 
 ### Minimum Historical Balances
 This attribute details the minimum daily ending balance for a user
 
 This attribute can be calculated for a single account or across all the users depository accounts.
-* Account level attribute: account/negative_record.py
-* Report level attribute: report/negative_record.py
+* Account level attribute: account/historical_balances.py
+* Report level attribute: report/historical_balances.py
 
 ### Maximum Historical Balances
 This attribute details the maximum daily ending balance for a user
 
 This attribute can be calculated for a single account or across all the users depository accounts.
-* Account level attribute: account/negative_record.py
-* Report level attribute: report/negative_record.py
+* Account level attribute: account/historical_balances.py
+* Report level attribute: report/historical_balances.py

--- a/bank_income/README.md
+++ b/bank_income/README.md
@@ -1,6 +1,6 @@
 # Bank Income Attributes
 
-The [Plaid Bank Income](https://plaid.com/products/income/) product helps verify a user's income using bank data, including income from payroll, government income, and other sources. This library details how to calculate key attributes from the Bank Income data that can be used in your verification flows. Each attribute has a corresponding function that you can use or adapt to further understand your user’s finances.
+The [Plaid Bank Income](https://plaid.com/docs/income/bank-income/) product helps verify a user's income using bank data, including income from payroll, government income, and other sources. This library details how to calculate key attributes from the Bank Income data that can be used in your verification flows. Each attribute has a corresponding function that you can use or adapt to further understand your user’s finances.
 
 Please reach out to your account manager if you have further questions on how to utilize the attributes.
 


### PR DESCRIPTION
## Summary

Two README issues found while auditing public sample apps:

**\`assets/README.md\` — wrong file references in Historical Balances section.** The three subsections (Average / Minimum / Maximum Historical Balances) pointed readers at \`account/negative_record.py\` and \`report/negative_record.py\`, but the actual functions (\`avg_historical_balance\`, \`min_historical_balance\`, \`max_historical_balance\`) live in \`historical_balances.py\` in both directories. Anyone following the doc opened the wrong file. Negative-records references elsewhere in the README are correct and untouched.

**\`bank_income/README.md\` — stale Bank Income link.** The intro link to \`https://plaid.com/products/income/\` 301-redirects to \`/check/underwriting/\`, which is the Plaid Check underwriting product — a different product, not Bank Income. Replaced with the canonical Bank Income docs URL at \`https://plaid.com/docs/income/bank-income/\` (verified 200).