### PR TITLE
Mark library as legacy and point users to Plaid Check Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]
 > **This library covers Plaid's legacy credit products — Asset Report and Bank Income.** For most new integrations, these have been superseded by [Plaid Check](https://plaid.com/check/underwriting/) (Plaid's Consumer Reporting Agency / CRA products).
 >
-> Plaid Check computes many of the attributes in this library directly in the API response, so you generally do not need to run these scripts to derive them. For example, [the Base Report](https://plaid.com/docs/api/products/check/) returns NSF/overdraft transaction counts (`nsf_overdraft_transactions_count`), total inflow/outflow amounts (`total_inflow_amount`, `total_outflow_amount`), and average balances (`average_balance`, `most_recent_thirty_day_average_balance`, `average_monthly_balances`) — with prebuilt 30/60/90-day rolling windows on the cash flow and overdraft fields. Income Insights returns monthly income metrics and `next_payment_date` directly.
+> Plaid Check computes many of the attributes in this library directly in the API response. For example, [the Base Report](https://plaid.com/docs/api/products/check/) returns NSF/overdraft transaction counts (`nsf_overdraft_transactions_count`), total inflow/outflow amounts (`total_inflow_amount`, `total_outflow_amount`), and average balances (`average_balance`, `most_recent_thirty_day_average_balance`, `average_monthly_balances`) — with prebuilt 30/60/90-day rolling windows on the cash flow and overdraft fields. Income Insights returns monthly income metrics and `next_payment_date` directly.
 >
 > **For new underwriting integrations, start with the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart)** (Base Report, Income Insights, Network Insights, CashFlow Insights, LendScore, Home Lending).
 >

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 >
 > **For new underwriting integrations, start with the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart)** (Base Report, Income Insights, Network Insights, CashFlow Insights, LendScore, Home Lending).
 >
-> Use this library only if you are maintaining an existing Asset Report or Bank Income integration, or if you need a calculation Plaid Check does not expose directly (for example, loan-disbursement summaries or min/max balance).
+> Use this library only if you are maintaining an existing Asset Report or Bank Income integration. The functions here operate on Asset Report and Bank Income response objects and are not compatible with Plaid Check responses.
 
 Plaid provides a suite of credit products to help lenders gain a holistic view into a user’s finances. Today, these products are used by lenders in verticals across mortgage, personal, and business among others - see the [Credit Underwriting Whitepaper](https://plaid.com/credit-underwriting-whitepaper/) for more details on our product offerings and how Plaid’s Assets and Income improve automation and lending process for our customers today. 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Plaid Credit Attributes Library
 
+> [!IMPORTANT]
+> **This library covers Plaid's legacy credit products — Asset Report and Bank Income.** For most new integrations, these have been superseded by [Plaid Check](https://plaid.com/check/underwriting/) (Plaid's Consumer Reporting Agency / CRA products).
+>
+> Plaid Check computes many of the attributes in this library directly in the API response, so you generally do not need to run these scripts to derive them. For example, [the Base Report](https://plaid.com/docs/api/products/check/) returns NSF/overdraft transaction counts (`nsf_overdraft_transactions_count`), total inflow/outflow amounts (`total_inflow_amount`, `total_outflow_amount`), and average balances (`average_balance`, `most_recent_thirty_day_average_balance`, `average_monthly_balances`) — with prebuilt 30/60/90-day rolling windows on the cash flow and overdraft fields. Income Insights returns monthly income metrics and `next_payment_date` directly.
+>
+> **For new underwriting integrations, start with the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart)** (Base Report, Income Insights, Network Insights, CashFlow Insights, LendScore, Home Lending).
+>
+> Use this library only if you are maintaining an existing Asset Report or Bank Income integration, or if you need a calculation Plaid Check does not expose directly (for example, loan-disbursement summaries or min/max balance).
+
 Plaid provides a suite of credit products to help lenders gain a holistic view into a user’s finances. Today, these products are used by lenders in verticals across mortgage, personal, and business among others - see the [Credit Underwriting Whitepaper](https://plaid.com/credit-underwriting-whitepaper/) for more details on our product offerings and how Plaid’s Assets and Income improve automation and lending process for our customers today. 
 
 In order to better aid the underwriting process utilizing alternative bank data, we have compiled these attributes on Github for developers and data scientists. This library details how to calculate key attributes from the products that can be used in your underwriting flows across negative records, debt insights, income and more. Each attribute has a corresponding function that you can use or adapt to further understand your user’s finances.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,5 +1,8 @@
 # Asset Report Attributes
 
+> [!IMPORTANT]
+> **Asset Report is a legacy credit product.** For most new integrations, see the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart). [Plaid Check Base Report](https://plaid.com/docs/api/products/check/) returns NSF/overdraft counts, inflow/outflow totals, and average balances — including 30/60/90-day windows — directly in the response, so you generally do not need the scripts in this directory to compute them.
+
 The [Plaid Asset Report](https://plaid.com/products/assets/) contains a holistic view into a user’s finances, including their transactions, balances, and historical cash flows in their financial accounts. Today, Assets is used by lenders in all verticals across mortgage, personal, and business among others - see the [Credit Underwriting Whitepaper](https://plaid.com/credit-underwriting-whitepaper/) for more details on our product offerings and how Plaid’s Assets and Income improve automation and lending process for our customers today. 
 
 In order to better aid the underwriting process utilizing alternative bank data, we have compiled these attributes on Github for developers and data scientists. This library details how to calculate key attributes from the report that can be used in your underwriting flows across negative records, debt insights, unusual account activity, cash flow and historical balances. Each attribute has a corresponding function that you can use or adapt to further understand your user’s finances. Please note in order to use these attributes, you will need credit categories enabled. 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,7 +1,7 @@
 # Asset Report Attributes
 
 > [!IMPORTANT]
-> **Asset Report is a legacy credit product.** For most new integrations, see the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart). [Plaid Check Base Report](https://plaid.com/docs/api/products/check/) returns NSF/overdraft counts, inflow/outflow totals, and average balances — including 30/60/90-day windows — directly in the response, so you generally do not need the scripts in this directory to compute them.
+> **Asset Report is a legacy credit product.** For most new integrations, see the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart). [Plaid Check Base Report](https://plaid.com/docs/api/products/check/) returns NSF/overdraft counts, inflow/outflow totals, and average balances — including 30/60/90-day windows — directly in the response. The scripts in this directory operate on Asset Report response objects only and cannot be used against Plaid Check responses.
 
 The [Plaid Asset Report](https://plaid.com/products/assets/) contains a holistic view into a user’s finances, including their transactions, balances, and historical cash flows in their financial accounts. Today, Assets is used by lenders in all verticals across mortgage, personal, and business among others - see the [Credit Underwriting Whitepaper](https://plaid.com/credit-underwriting-whitepaper/) for more details on our product offerings and how Plaid’s Assets and Income improve automation and lending process for our customers today. 
 

--- a/bank_income/README.md
+++ b/bank_income/README.md
@@ -1,7 +1,7 @@
 # Bank Income Attributes
 
 > [!IMPORTANT]
-> **Bank Income is a legacy credit product.** For most new integrations, see the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart). [Plaid Check Income Insights](https://plaid.com/docs/api/products/check/) returns monthly income metrics and `next_payment_date` directly in the response, so you generally do not need the scripts in this directory to compute them.
+> **Bank Income is a legacy credit product.** For most new integrations, see the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart). [Plaid Check Income Insights](https://plaid.com/docs/api/products/check/) returns monthly income metrics and `next_payment_date` directly in the response. The scripts in this directory operate on Bank Income response objects only and cannot be used against Plaid Check responses.
 
 The [Plaid Bank Income](https://plaid.com/docs/income/bank-income/) product helps verify a user's income using bank data, including income from payroll, government income, and other sources. This library details how to calculate key attributes from the Bank Income data that can be used in your verification flows. Each attribute has a corresponding function that you can use or adapt to further understand your user’s finances.
 

--- a/bank_income/README.md
+++ b/bank_income/README.md
@@ -1,5 +1,8 @@
 # Bank Income Attributes
 
+> [!IMPORTANT]
+> **Bank Income is a legacy credit product.** For most new integrations, see the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart). [Plaid Check Income Insights](https://plaid.com/docs/api/products/check/) returns monthly income metrics and `next_payment_date` directly in the response, so you generally do not need the scripts in this directory to compute them.
+
 The [Plaid Bank Income](https://plaid.com/docs/income/bank-income/) product helps verify a user's income using bank data, including income from payroll, government income, and other sources. This library details how to calculate key attributes from the Bank Income data that can be used in your verification flows. Each attribute has a corresponding function that you can use or adapt to further understand your user’s finances.
 
 Please reach out to your account manager if you have further questions on how to utilize the attributes.


### PR DESCRIPTION
## Summary

Asset Report and Bank Income are Plaid's legacy credit products. Plaid Check (the CRA product suite) has superseded them for most new underwriting integrations, and the Plaid Check API already computes many of the attributes this library derives — without any post-processing on the customer side.

Add an \`[!IMPORTANT]\` banner at the top of the main README plus shorter banners on \`assets/README.md\` and \`bank_income/README.md\`. The main banner calls out the specific Base Report and Income Insights response fields that replace this library's calculations and points readers at \`plaid/credit-quickstart\` for the recommended workflow. It also makes clear that this library only works on Asset Report and Bank Income response objects — it is **not** a fallback you can run against Plaid Check responses.

## What the banner claims (verified against the [Plaid Check API reference](https://plaid.com/docs/api/products/check/))

| This library computes | Plaid Check returns directly |
| --- | --- |
| OD/NSF event count / monthly summary | \`nsf_overdraft_transactions_count\`, plus \`_30d\` / \`_60d\` / \`_90d\` variants |
| Inflow / outflow totals, monthly summaries | \`total_inflow_amount\`, \`total_outflow_amount\`, plus 30/60/90-day variants |
| Average / monthly historical balances | \`average_balance\`, \`most_recent_thirty_day_average_balance\`, \`average_monthly_balances\` |
| Bank Income monthly average, next pay date | Income Insights \`monthly\` income metrics and \`next_payment_date\` |

Loan-disbursement / loan-payment summaries and min/max balance are not directly returned by Plaid Check today, but since this library can't run against Plaid Check responses, the banner does not suggest using it as a supplement.

Claude Session: 840e8428-450d-4184-8201-7392bd607741