### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 >
 > Use this library only if you are maintaining an existing Asset Report or Bank Income integration. The functions here operate on Asset Report and Bank Income response objects and are not compatible with Plaid Check responses.
 
-Plaid provides a suite of credit products to help lenders gain a holistic view into a user’s finances. Today, these products are used by lenders in verticals across mortgage, personal, and business among others - see the [Credit Underwriting Whitepaper](https://plaid.com/credit-underwriting-whitepaper/) for more details on our product offerings and how Plaid’s Assets and Income improve automation and lending process for our customers today. 
+Plaid provides a suite of credit products to help lenders gain a holistic view into a user’s finances. Today, these products are used by lenders in verticals across mortgage, personal, and business among others - see the [Credit Underwriting Whitepaper](https://plaid.com/credit-underwriting-whitepaper/) for more details on our product offerings and how Plaid’s Assets and Income improve automation and lending processes for our customers today. 
 
 In order to better aid the underwriting process utilizing alternative bank data, we have compiled these attributes on Github for developers and data scientists. This library details how to calculate key attributes from the products that can be used in your underwriting flows across negative records, debt insights, income and more. Each attribute has a corresponding function that you can use or adapt to further understand your user’s finances.
 


### PR DESCRIPTION
Documentation-only fix found during a README audit. No code changes.

- "automation and lending process" → "automation and lending processes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: ed109da0-3731-4af2-a267-06897819a519